### PR TITLE
(#25) Switch to using a global.json file

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-ARG VARIANT="3.1-focal"
+ARG VARIANT="6.0-focal"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
-ARG NODE_VERSION="14"
+ARG NODE_VERSION="16"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,8 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"VARIANT": "3.1-focal",
-			"NODE_VERSION": "14"
+			"VARIANT": "6.0-focal",
+			"NODE_VERSION": "16"
 		}
 	},
 	"settings": {},

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '3.1.301' # SDK Version to use.
+        global-json-file: global.json
 
     - name: Publish-Documentation
       uses: cake-build/cake-action@v1

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '3.1.301' # SDK Version to use.
+        global-json-file: global.json
 
     - name: Statiq-Build
       uses: cake-build/cake-action@v1

--- a/global.json
+++ b/global.json
@@ -1,0 +1,9 @@
+{
+	"projects": [
+	    "src"
+	],
+	"sdk": {
+	    "version": "6.0.404",
+	    "rollForward": "latestFeature"
+	}
+    }


### PR DESCRIPTION
## Description Of Changes

Switch to using a global.json file for defining .NET Framework version.

## Motivation and Context

This means that the required .NET framework version is defined in one place, and the GitHub Action workflows can be targetted to use the same information, rather than duplicating it in multiple places.

## Testing

N/A

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Relates to #25