### PR TITLE
(doc) No auto login from x86 PS on x64 OS

### DIFF
--- a/input/installingpackages.md
+++ b/input/installingpackages.md
@@ -16,7 +16,7 @@ $cred=Get-Credential domain\username
 Install-BoxstarterPackage -PackageName "MyPackage1","MyPackage2" -Credential $cred
 ```
 
-This will install the MyPackage1 and MyPackage2 packages locally and use the credentials given for any auto login needed after a reboot.
+This will install the MyPackage1 and MyPackage2 packages locally and use the credentials given for any auto login needed after a reboot. Note that you cannot use auto login from a [32-bit PowerShell session on a 64-bit operating system](https://github.com/chocolatey/boxstarter/issues/1).
 
 There may be times when you either know that no reboot will be needed or you want to ensure that none take place. To tell Boxstarter not to perform any reboots, even if a pending reboot is detected, use the `-DisableReboots` argument.
 


### PR DESCRIPTION
## Description Of Changes
Note that auto login does not work when running from a 32-bit PowerShell session on an x64 operating system.

[Another PR](https://github.com/chocolatey/boxstarter/pull/542) was raised to cover changes to the PowerShell function help.

## Motivation and Context
This was noted in this issue https://github.com/chocolatey/boxstarter/issues/1

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    
## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A