### PR TITLE
(maint) Add spell check linting to repository

### DIFF
--- a/.github/workflows/full-linting.yml
+++ b/.github/workflows/full-linting.yml
@@ -1,0 +1,31 @@
+name: Full Linting
+on:
+  workflow_dispatch:
+
+jobs:
+  misspell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run misspell with reviewdog
+        uses: reviewdog/action-misspell@v1.14.0
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: 'github-check'
+          level: warning
+          locale: "US"
+          path: |
+            input
+            src
+          filter_mode: nofilter
+  languagetool:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run LanguageTool with reviewdog
+        uses: reviewdog/action-languagetool@v1.12.0
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: 'github-check'
+          level: warning # Only valid if running on a commit, ie through push to master branch
+          language: en-US

--- a/.github/workflows/full-linting.yml
+++ b/.github/workflows/full-linting.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup ReviewDog
+        uses: reviewdog/action-setup@v1.0.6
       - name: Run misspell with reviewdog
         uses: reviewdog/action-misspell@v1.14.0
         with:
@@ -22,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup ReviewDog
+        uses: reviewdog/action-setup@v1.0.6
       - name: Run LanguageTool with reviewdog
         uses: reviewdog/action-languagetool@v1.12.0
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,45 @@
+name: Linting
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  misspell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haya14busa/action-cond@v1
+        id: reporter
+        with:
+          cond: ${{ github.event_name == 'pull_request' }}
+          if_true: "github-pr-review"
+          if_false: "github-check"
+      - name: Run misspell with reviewdog
+        uses: reviewdog/action-misspell@v1.14.0
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: ${{ steps.reporter.outputs.value }}
+          level: warning
+          locale: "US"
+          path: |
+            input
+            src
+  languagetool:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haya14busa/action-cond@v1
+        id: reporter
+        with:
+          cond: ${{ github.event_name == 'pull_request' }}
+          if_true: "github-pr-review"
+          if_false: "github-check"
+      - name: Run LanguageTool with reviewdog
+        uses: reviewdog/action-languagetool@v1.12.0
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: ${{ steps.reporter.outputs.value }}
+          level: warning # Only valid if running on a commit, ie through push to master branch
+          language: en-US

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,6 +5,11 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   misspell:
     runs-on: ubuntu-latest
@@ -13,13 +18,15 @@ jobs:
       - uses: haya14busa/action-cond@v1
         id: reporter
         with:
-          cond: ${{ github.event_name == 'pull_request' }}
+          cond: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
           if_true: "github-pr-review"
           if_false: "github-check"
+      - name: Setup ReviewDog
+        uses: reviewdog/action-setup@v1.0.6
       - name: Run misspell with reviewdog
         uses: reviewdog/action-misspell@v1.14.0
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: ${{ steps.reporter.outputs.value }}
           level: warning
           locale: "US"
@@ -33,13 +40,15 @@ jobs:
       - uses: haya14busa/action-cond@v1
         id: reporter
         with:
-          cond: ${{ github.event_name == 'pull_request' }}
+          cond: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
           if_true: "github-pr-review"
           if_false: "github-check"
+      - name: Setup ReviewDog
+        uses: reviewdog/action-setup@v1.0.6
       - name: Run LanguageTool with reviewdog
         uses: reviewdog/action-languagetool@v1.12.0
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: ${{ steps.reporter.outputs.value }}
           level: warning # Only valid if running on a commit, ie through push to master branch
           language: en-US

--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -72,7 +72,7 @@ ShowInSidebar: false
             <img loading="lazy" class="w-75" src='@Context.GetLink("/assets/images/undraw_speed_test.svg")' alt="Launch Boxstarter With one Easy URL" />
         </div>
         <div class="col-md-6">
-            <p class="text-pink fw-bold font-monospace mb-2 lead"># Convienient</p>
+            <p class="text-pink fw-bold font-monospace mb-2 lead"># Convenient</p>
             <h2 class="mt-0">Launch With One Easy URL</h2>
             <p class="lead">You can use Boxstarter to install a complete environment or install a small set of tools and Windows settings with absolutely no software pre installed using an easy to remember URL.</p>
             <div class="pt-3">


### PR DESCRIPTION
## Description Of Changes

This PR adds two new workflows that uses misspell and LanguageTool
to run verification on the changed text in a PR, or the entire repository
on demand to verify that there are no spelling mistakes and that sentences
are correct.

## Motivation and Context

We should strive to not have spelling mistakes when merging PR's into the repository.

## Testing

Workflows tested through my own fork

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Build related

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A